### PR TITLE
fix: post access

### DIFF
--- a/src/hooks/payload.ts
+++ b/src/hooks/payload.ts
@@ -48,7 +48,7 @@ export function usePosts(board: Optional<string | Board>, page: number) {
 		queryFn: () =>
 			getPayloadAll(
 				"posts",
-				{ board: { equals: id } },
+				{ "board.id": { equals: id } },
 				new URLSearchParams({
 					sort: "-createdAt",
 					limit: "10",
@@ -77,7 +77,7 @@ export function useComments(post: Optional<string | Post>) {
 		queryFn: () =>
 			getPayloadAll(
 				"comments",
-				{ post: { equals: id } },
+				{ "post.id": { equals: id } },
 				new URLSearchParams({ depth: "0", sort: "createdAt" }),
 			),
 		enabled: !!post,


### PR DESCRIPTION
This pull request updates query filters in the `usePosts` and `useComments` hooks to use fully qualified property paths for better clarity and compatibility with the backend API.

Key changes:

* **Query filter updates in `usePosts`:**
  - Modified the filter for the `board` property from `{ board: { equals: id } }` to `{ "board.id": { equals: id } }` to explicitly reference the `id` field of the `board` object. (`src/hooks/payload.ts`, [src/hooks/payload.tsL51-R51](diffhunk://#diff-9d76ef8020debff4b9ea54ab8013e98d383c709d1feee56135efdb08dfb94cdfL51-R51))

* **Query filter updates in `useComments`:**
  - Modified the filter for the `post` property from `{ post: { equals: id } }` to `{ "post.id": { equals: id } }` to explicitly reference the `id` field of the `post` object. (`src/hooks/payload.ts`, [src/hooks/payload.tsL80-R80](diffhunk://#diff-9d76ef8020debff4b9ea54ab8013e98d383c709d1feee56135efdb08dfb94cdfL80-R80))