### PR TITLE
chore: bump bootcamp idx

### DIFF
--- a/src/app/[lng]/labs/page.tsx
+++ b/src/app/[lng]/labs/page.tsx
@@ -37,7 +37,7 @@ export default async function LabsPage() {
 					<>
 						<div className="absolute animate-bounce top-0 flex flex-col items-center mr-0 sm:mr-64">
 							<p className="bg-[#D9D9D9] text-identity-800 font-bold px-4 py-2 rounded-full">
-								4회 부트캠프 신청{" "}
+								5회 부트캠프 신청{" "}
 								<span className="text-identity-400">
 									{Math.floor(left / 1000 / 60 / 60 / 24)}일 후 마감!
 								</span>


### PR DESCRIPTION
This pull request makes a minor update to the `LabsPage` component. The change updates the displayed bootcamp application round from "4회" to "5회" to reflect the new application cycle. ([src/app/[lng]/labs/page.tsxL40-R40](diffhunk://#diff-d09581ff4640e0e3299c7fa8afda48a2ad24f4a2900217bd7caf7b5aa36281d8L40-R40))