### PR TITLE
ci: run SST via pnpm (pnpm sst) instead of curl-installed CLI

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -53,7 +53,5 @@ jobs:
           REFRESH_KEY: ${{ secrets.REFRESH_KEY }}
         run: |
           corepack enable
-          curl -fsSL https://ion.sst.dev/install | VERSION=4.14.3 bash
-          /home/runner/.sst/bin/sst version | grep -qF "4.14.3" || { echo "::error::SST CLI is not 4.14.3"; exit 1; }
           pnpm install
-          /home/runner/.sst/bin/sst deploy --stage develop
+          pnpm sst deploy --stage develop

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -53,7 +53,5 @@ jobs:
           REFRESH_KEY: ${{ secrets.REFRESH_KEY }}
         run: |
           corepack enable && \
-          curl -fsSL https://ion.sst.dev/install | VERSION=4.14.3 bash && \
-          /home/runner/.sst/bin/sst version | grep -qF "4.14.3" && \
           pnpm install && \
-          /home/runner/.sst/bin/sst deploy --stage production
+          pnpm sst deploy --stage production


### PR DESCRIPTION
## Summary
Run the deploy via the **pnpm-installed SST** (`pnpm sst deploy`) instead of the `curl https://ion.sst.dev/install | bash` CLI.

- Deploys the SST version pinned in `package.json` + lockfile (**4.14.3**, supply-chain-compliant) — no version drift, no separate version guard needed.
- Removes the remote-script supply-chain risk and the `ion.sst.dev` network dependency from the deploy step.
- Safe with our pnpm build-allowlist: the `sst` package has **no postinstall**; its bin is a JS shim that resolves a prebuilt platform binary from an optional dependency (`sst-linux-x64`), already in the lockfile.

Applies to both `deploy-dev.yml` and `deploy-main.yml`.

## Note on sequencing
This targets `develop`. To get `pnpm sst` into the production release, merge this **before** PR #34 (develop → main) — since #34's head is `develop`, it will then include this change automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)