### PR TITLE
ci: cache pnpm store instead of .next/cache (fix OpenNext deploy failure)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -24,19 +24,14 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_NAME }}
           aws-region: us-east-1
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: "24"
-
-      - name: Setup Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ github.workspace }}/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+          cache: "pnpm"
 
       - name: Deploy to AWS
         env:
@@ -52,6 +47,5 @@ jobs:
           TOKEN_SECRET: ${{ secrets.TOKEN_SECRET }}
           REFRESH_KEY: ${{ secrets.REFRESH_KEY }}
         run: |
-          corepack enable
-          pnpm install
+          pnpm install --frozen-lockfile
           pnpm sst deploy --stage develop

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -16,10 +16,10 @@ jobs:
       name: development
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_NAME }}
           aws-region: us-east-1
@@ -28,7 +28,7 @@ jobs:
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "24"
           cache: "pnpm"

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -16,10 +16,10 @@ jobs:
       name: production
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_NAME }}
           aws-region: us-east-1
@@ -28,7 +28,7 @@ jobs:
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "24"
           cache: "pnpm"

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -24,19 +24,14 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_NAME }}
           aws-region: us-east-1
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: "24"
-
-      - name: Setup Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ github.workspace }}/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+          cache: "pnpm"
 
       - name: Deploy to AWS
         env:
@@ -52,6 +47,5 @@ jobs:
           TOKEN_SECRET: ${{ secrets.TOKEN_SECRET }}
           REFRESH_KEY: ${{ secrets.REFRESH_KEY }}
         run: |
-          corepack enable && \
-          pnpm install && \
+          pnpm install --frozen-lockfile && \
           pnpm sst deploy --stage production


### PR DESCRIPTION
## Problem
The `develop` deploy (from PR #35's merge) failed in **OpenNext's `createCacheAssets`**:
```
SyntaxError: Unexpected end of JSON input
  at createCacheAssets (@opennextjs/aws/dist/build/createAssets.js:141)
```
OpenNext strictly `JSON.parse`s every file under `.next/cache`, and the restored GitHub Actions cache contained an empty/partial entry. It's **intermittent and recurring** — run #33 *saved* the `.next/cache` that run #35 then *restored* and choked on. (`pnpm sst` / SST 4.14.3 / OpenNext 3.6.6 are identical across passing and failing runs, so the CLI change is not the cause.)

## Fix — follow qmr-web's caching approach
qmr-web doesn't cache `.next/cache`; it caches the **pnpm store**. Adopting the same here:
- Add `pnpm/action-setup` (SHA-pinned `v5.0.0`, reads `packageManager`) and set `cache: "pnpm"` on `actions/setup-node` → caches the pnpm store, keyed by `pnpm-lock.yaml`.
- Removed the `.next/cache` `actions/cache` step (its key was also broken — referenced `package-lock.json`, which doesn't exist in this pnpm repo).
- `pnpm install` → `pnpm install --frozen-lockfile` (CI best practice; honors the supply-chain-checked lockfile).

This keeps installs fast without feeding a fragile Next cache into OpenNext. Applied to both `deploy-dev.yml` and `deploy-main.yml`. The two poisoned caches were also deleted.

## Merge order
Merge this into `develop` **before** the release PR #34 (develop → main) so production ships with the fixed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)